### PR TITLE
Changed StringIO to BytesIO

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -169,7 +169,7 @@ class GardenTool(object):
         animation = '\\|/-'
         index = 0
         count = 0
-        data = bytes()
+        data = b''
         for buf in r.iter_content(1024):
             index += 1
             data += buf


### PR DESCRIPTION
...fixing the TypeError that happens when concatenating the empty string with bytes. Initialize data in download to bytes rather than the empty string.

Fixes #2

Also fix AttributeError when script isn't supplied a command.
