### PR TITLE
Prevent crash when options has no 'kivy' attribute

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -87,7 +87,7 @@ class GardenTool(object):
         else:
             parser.print_help()
 
-        if self.options.kivy and garden_kivy_dir is None:
+        if getattr(self.options, 'kivy', False) and garden_kivy_dir is None:
             print('--kivy provided; cannot find kivy')
             sys.exit(0)
 


### PR DESCRIPTION
When you run a garden command that does not have a `--kivy` option, e.g., `garden search` or `garden -h`, garden crashes trying to check if the --kivy flag is set because `options` has no kivy attribute:

```
Traceback (most recent call last):
  File "/Applications/Kivy3.app/Contents/Frameworks/python/3.5.0/bin/garden", line 223, in <module>
    GardenTool().main(sys.argv[1:])
  File "/Applications/Kivy3.app/Contents/Frameworks/python/3.5.0/bin/garden", line 90, in main
    if self.options.kivy and garden_kivy_dir is None:
AttributeError: 'Namespace' object has no attribute 'kivy'
```

Performing the check with `getattr` and a default fixes the issue. 

I guess this isn't a big deal, as it looks like the check isn't performed until after everything has happened, but it's a bit confusing for new users (like myself).

