### PR TITLE
fix stream download ("prefetch" option changed to "stream")

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -189,7 +189,7 @@ class GardenTool(object):
                 package)
 
         print('Downloading {} ...'.format(url))
-        r = requests.get(url)#, prefetch=False)
+        r = requests.get(url, stream=True)
         if r.status_code != 200:
             print('Unable to find the garden package. (error={})'.format(
                 r.status_code))


### PR DESCRIPTION
stream download option `prefetch` changed to `stream`, and the logic was inverted.
