### PR TITLE
Fix for paths containing whitespace

### DIFF
--- a/bin/garden.bat
+++ b/bin/garden.bat
@@ -1,1 +1,1 @@
-python.exe %~dp0garden %*
+python.exe "%~dp0garden" %*


### PR DESCRIPTION
Not sure about the missing newline, but the quotes are necessary. :ghost: 