### PR TITLE
Force lowercase for packages

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -79,6 +79,7 @@ class GardenTool(object):
         p.set_defaults(func=self.cmd_uninstall)
 
         self.options = options = parser.parse_args(argv)
+        options.package = [p.lower() for p in options.package]
 
         if hasattr(options, 'func'):
             options.func()


### PR DESCRIPTION
Fixes #26 

It's not that garden doesn't handle capitals properly, its GitHub that allows whatever capitals because it converts to lowercase for itself (and we happily use the uppercase), so it breaks on folder being non-existing.

* https://github.com/kivy-garden/garden.filebrowser
* https://github.com/kivy-garden/garden.FileBrowser
* https://github.com/kivy-garden/garden.fIlEbRowser