### PR TITLE
Bugfix to prevent AttributeError when checking various command line a…

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -78,17 +78,19 @@ class GardenTool(object):
                 help='Name of the package to uninstall')
         p.set_defaults(func=self.cmd_uninstall)
 
-        self.options = options = parser.parse_args(argv)
-        options.package = [p.lower() for p in options.package]
+        self.options = parser.parse_args(argv)
 
-        if hasattr(options, 'func'):
-            options.func()
+        if hasattr(self.options, 'package'):
+          self.options.package = [p.lower() for p in self.options.package]
+
+        if hasattr(self.options, 'func'):
+            self.options.func()
 
         # No cmd supplied, print help message
         else:
             parser.print_help()
 
-        if getattr(self.options, 'kivy', False) and garden_kivy_dir is None:
+        if hasattr(self.options, 'kivy') and garden_kivy_dir is None:
             print('--kivy provided; cannot find kivy')
             sys.exit(0)
 


### PR DESCRIPTION
…rguments.

This fixes errors when attempting to use list & search subparsers.

> $ garden search contextmenu
[INFO              ] [Logger      ] Record log in C:\Users\Minion\.kivy\logs\kivy_17-05-05_34.txt
[INFO              ] [Kivy        ] v1.9.1
[INFO              ] [Python      ] v3.6.1 (v3.6.1:69c0db5, Mar 21 2017, 17:54:52) [MSC v.1900 32 bi                                                                                                          t (Intel)]
 Traceback (most recent call last):
   File "C:/Software/Python/Python36-32/Scripts/garden", line 224, in <module>
     GardenTool().main(sys.argv[1:])
   File "C:/Software/Python/Python36-32/Scripts/garden", line 82, in main
     options.package = [p.lower() for p in options.package]
 AttributeError: 'Namespace' object has no attribute 'package'
