### PR TITLE
Update garden

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -79,7 +79,7 @@ class GardenTool(object):
         p.set_defaults(func=self.cmd_uninstall)
 
         self.options = options = parser.parse_args(argv)
-        options.package = [p.lower() for p in options.package]
+        options.package = [p.lower() for p in getattr(options, 'package', ())]
 
         if hasattr(options, 'func'):
             options.func()


### PR DESCRIPTION
Fix `AttributeError` when no package is given (e.g. `list` command).

Relates to #23 