### PR TITLE
Add --no-download-progress install flag. Closes kivy-garden/garden#7

### DIFF
--- a/bin/garden
+++ b/bin/garden
@@ -64,6 +64,8 @@ class GardenTool(object):
                 help='Use the kivy garden directory (kivy/garden)')
         p.add_argument('--upgrade', action='store_true',
                 help='Force the installation')
+        p.add_argument('--no-download-progress', action='store_false', dest='animate',
+                help='Disable download progress indicator')
         p.add_argument('package', nargs=1,
                 help='Name of the package to install')
         p.set_defaults(func=self.cmd_install)
@@ -138,7 +140,7 @@ class GardenTool(object):
             print('Use --upgrade to upgrade.')
             sys.exit(0)
 
-        fd = self.download(src_package)
+        fd = self.download(src_package, opts.animate)
         tempdir = tempfile.mkdtemp(prefix='garden-')
         try:
             self.extract(fd, tempdir)
@@ -185,7 +187,7 @@ class GardenTool(object):
             return 'garden.' + package
         return package
 
-    def download(self, package):
+    def download(self, package, animate):
         url = 'https://github.com/kivy-garden/{}/archive/master.zip'.format(
                 package)
 
@@ -204,8 +206,9 @@ class GardenTool(object):
             index += 1
             data += buf
             count += len(buf)
-            print('Progression', count, animation[index % len(animation)], '\r')
-            sys.stdout.flush()
+            if animate:
+                print('Progression', count, animation[index % len(animation)], '\r')
+                sys.stdout.flush()
         print('Download done ({} downloaded)'.format(count))
 
         return BytesIO(data)


### PR DESCRIPTION
I was a bit annoyed with garden filling up my Travis logs with progress spinner lines (1500 lines for a single flower!) so I decided to add a command line option to disable the spinner e.g. for use with unattended installs.